### PR TITLE
FIX get transaction price endpoint path

### DIFF
--- a/server/http-api.md
+++ b/server/http-api.md
@@ -652,7 +652,7 @@ A **Content-Type** tag can be submitted with a transaction, the tag will then be
 The default Content-Type is **text/html**.
 {% endhint %}
 
-{% api-method method="get" host="https://arweave.net" path="price/{bytes}/{target}" %}
+{% api-method method="get" host="https://arweave.net" path="/price/{bytes}/{target}" %}
 {% api-method-summary %}
 Get Transaction Price
 {% endapi-method-summary %}


### PR DESCRIPTION
It renders as,

https://arweave.netprice/{bytes}/{target}

without the prefixed slash.