### PR TITLE
:recycle: refactor: go sdk consistency

### DIFF
--- a/server/http-api.md
+++ b/server/http-api.md
@@ -58,7 +58,7 @@ request(options, function (error, response, body) {
 
 ### Integrations
 
-Arweave specific wrappers and clients are currently in development to simplify common operations and API interactions, there are currently integrations for [Go](https://github.com/Dev43/arweave-go), [PHP](https://github.com/ArweaveTeam/arweave-php), [Scala](https://github.com/toknapp/arweave4s) \(which can also be used with Java and C\#\) and [JavaScript/TypeScript/NodeJS](https://github.com/ArweaveTeam/arweave-js).
+Arweave specific wrappers and clients are currently in development to simplify common operations and API interactions, there are currently integrations for [Go](https://github.com/everFinance/goar), [PHP](https://github.com/ArweaveTeam/arweave-php), [Scala](https://github.com/toknapp/arweave4s) \(which can also be used with Java and C\#\) and [JavaScript/TypeScript/NodeJS](https://github.com/ArweaveTeam/arweave-js).
 
 ## Schema
 


### PR DESCRIPTION
use everfinance/goar on http api page, to keep consistent go sdks link around the docs and is also the currently active sdk.